### PR TITLE
Single fisheye camera support

### DIFF
--- a/RenderingXCore/src/main/cpp/GeometryBuilder/UvSphere.cpp
+++ b/RenderingXCore/src/main/cpp/GeometryBuilder/UvSphere.cpp
@@ -21,7 +21,8 @@ std::vector<UvSphere::Vertex> UvSphere::createUvSphere(
         int longitudes,
         float verticalFovDegrees,
         float horizontalFovDegrees,
-        const MEDIA_FORMAT mediaFormat) {
+        const MEDIA_FORMAT mediaFormat,
+	const ROTATION rotation) {
     if (radius <= 0
         || latitudes < 1 || longitudes < 1
         || verticalFovDegrees <= 0 || verticalFovDegrees > 180
@@ -57,9 +58,33 @@ std::vector<UvSphere::Vertex> UvSphere::createUvSphere(
                 const float theta = quadWidthRads * i + (float) PI - horizontalFovRads / 2;
 
                 // Set vertex position data as Cartesian coordinates.
-                vertexData[v].x = -(float) (radius * std::sin(theta) * std::cos(phi));
-                vertexData[v].y =  (float) (radius * std::sin(phi));
-                vertexData[v].z =  (float) (radius * std::cos(theta) * std::cos(phi));
+		switch (rotation) {
+		case ROTATE_0:
+		    vertexData[v].x = -(float) (radius * std::cos(theta) * std::cos(phi));
+		    vertexData[v].y = (float) (radius * std::sin(theta) * std::cos(phi));
+		    vertexData[v].z = -(float) (radius * std::sin(phi));
+		    break;
+		case ROTATE_90:
+		    vertexData[v].x = -(float) (radius * std::sin(theta) * std::cos(phi));
+		    vertexData[v].y = -(float) (radius * std::cos(theta) * std::cos(phi));
+		    vertexData[v].z = -(float) (radius * std::sin(phi));
+		    break;
+		case ROTATE_180:
+		    vertexData[v].x = (float) (radius * std::cos(theta) * std::cos(phi));
+		    vertexData[v].y = -(float) (radius * std::sin(theta) * std::cos(phi));
+		    vertexData[v].z = -(float) (radius * std::sin(phi));
+		    break;
+		case ROTATE_270:
+		    vertexData[v].x = -(float) (radius * std::sin(theta) * std::cos(phi));
+		    vertexData[v].y = (float) (radius * std::cos(theta) * std::cos(phi));
+		    vertexData[v].z = -(float) (radius * std::sin(phi));
+		    break;
+		default: // No rotation
+		    vertexData[v].x = (float) (radius * std::cos(theta) * std::cos(phi));
+		    vertexData[v].y = (float) (radius * std::sin(theta) * std::cos(phi));
+		    vertexData[v].z = -(float) (radius * std::sin(phi));
+		    break;
+		}
                 //vertexData[v].y =  (float) (radius * sin(theta) * sin(phi));
                 //vertexData[v].z =  (float) (radius * cos(theta));
 

--- a/RenderingXCore/src/main/cpp/GeometryBuilder/UvSphere.h
+++ b/RenderingXCore/src/main/cpp/GeometryBuilder/UvSphere.h
@@ -32,6 +32,8 @@ public:
  */
     MEDIA_EQUIRECT_STEREO_TOP_BOTTOM = 2,
     };
+    // Clockwise rotation
+    enum ROTATION { ROTATE_0, ROTATE_90, ROTATE_180, ROTATE_270 };
 // The vertex contains texture coordinates for both the left & right eyes. If the scene is
 // rendered in VR, the appropriate part of the vertex will be selected at runtime. For a mono
 // scene, only the left eye's UV coordinates are used.
@@ -61,7 +63,8 @@ public:
             int longitudes,
             float verticalFovDegrees,
             float horizontalFovDegrees,
-            MEDIA_FORMAT mediaFormat);
+            MEDIA_FORMAT mediaFormat,
+            ROTATION rotation);
 };
 
 


### PR DESCRIPTION
Adds support for video from a single fisheye camera and for rotation of the camera frame.

This is not necessarily complete, but should add initial support for single fisheye cameras.