### PR TITLE
Use submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LiveVideo10ms"]
+	path = LiveVideo10ms
+	url = git@github.com:Consti10/LiveVideo10ms.git

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,6 +3,6 @@ include ':RenderingXExample'
 
 //Comment when using artifacts from jitpack
 include ':Shared'
-project(':Shared').projectDir=new File('..\\LiveVideo10ms\\Shared')
+project(':Shared').projectDir=new File('LiveVideo10ms/Shared')
 include ':VideoCore'
-project(':VideoCore').projectDir=new File('..\\LiveVideo10ms\\VideoCore')
+project(':VideoCore').projectDir=new File('LiveVideo10ms/VideoCore')


### PR DESCRIPTION
Using a submodule to avoid error https://github.com/Consti10/RenderingX/issues/11 I run into next error.
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/3314607/151145252-d7796645-2048-49ac-b8b5-dacb908d2ce7.png">


I strongly recommend to use a CI to verify build